### PR TITLE
Add go to previous random image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Makefile*
 # QtCtreator Qml
 *.qmlproject.user
 *.qmlproject.user.*
+.qm
 
 # QtCtreator CMake
 CMakeLists.txt.user*
@@ -46,3 +47,5 @@ CMakeLists.txt.user*
 
 bin/*
 build/*
+share/
+usr/

--- a/i18n/qview_de.ts
+++ b/i18n/qview_de.ts
@@ -264,6 +264,10 @@
         <translation>Zufällige Datei</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>Vorherige zufällige Datei</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>Frame speichern als ...</translation>
     </message>
@@ -1407,6 +1411,10 @@ Keine Schreibberechtigung oder Datei ist schreibgeschützt.</translation>
     <message>
         <source>Random File</source>
         <translation>Zufällige Datei</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>Vorherige zufällige Datei</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/qview_es.ts
+++ b/i18n/qview_es.ts
@@ -264,6 +264,10 @@
         <translation>Archivo aleatorio</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>Archivo aleatorio anterior</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>Guardar fotograma como...</translation>
     </message>
@@ -1407,6 +1411,10 @@ No tiene permiso de escritura o el archivo es de solo lectura.</translation>
     <message>
         <source>Random File</source>
         <translation>Archivo aleatorio</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>Archivo aleatorio anterior</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/qview_fr.ts
+++ b/i18n/qview_fr.ts
@@ -264,6 +264,10 @@
         <translation>Fichier aléatoire</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>Fichier aléatoire précédent</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>Enregistrer la trame sous...</translation>
     </message>
@@ -1407,6 +1411,10 @@ Pas d&apos;autorisation d&apos;écriture ou le fichier est en lecture seule.</tr
     <message>
         <source>Random File</source>
         <translation>Fichier aléatoire</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>Fichier aléatoire précédent</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/qview_ja.ts
+++ b/i18n/qview_ja.ts
@@ -264,6 +264,10 @@
         <translation>ランダムなファイル</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>前のランダムなファイル</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>フレームを別名で保存...</translation>
     </message>
@@ -1407,6 +1411,10 @@ No write permission or file is read-only.</source>
     <message>
         <source>Random File</source>
         <translation>ランダムなファイル</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>前のランダムなファイル</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/qview_ko.ts
+++ b/i18n/qview_ko.ts
@@ -264,6 +264,10 @@
         <translation>무작위 파일</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>이전 무작위 파일</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>프레임을 다른 이름으로 저장...</translation>
     </message>
@@ -1407,6 +1411,10 @@ No write permission or file is read-only.</source>
     <message>
         <source>Random File</source>
         <translation>무작위 파일</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>이전 무작위 파일</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/qview_ru.ts
+++ b/i18n/qview_ru.ts
@@ -264,6 +264,10 @@
         <translation>Случайный файл</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>Предыдущий случайный файл</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>Сохранить кадр как...</translation>
     </message>
@@ -1407,6 +1411,10 @@ No write permission or file is read-only.</source>
     <message>
         <source>Random File</source>
         <translation>Случайный файл</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>Предыдущий случайный файл</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/qview_zh_Hans.ts
+++ b/i18n/qview_zh_Hans.ts
@@ -264,6 +264,10 @@
         <translation>随机一张图片</translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation>上一张随机图片</translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation>保存帧为...</translation>
     </message>
@@ -1406,6 +1410,10 @@ No write permission or file is read-only.</source>
     <message>
         <source>Random File</source>
         <translation>随机一张图片</translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
+        <translation>上一张随机图片</translation>
     </message>
     <message>
         <source>Zoom In</source>

--- a/i18n/template.ts
+++ b/i18n/template.ts
@@ -264,6 +264,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Previous Random File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Save Frame &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1393,6 +1397,10 @@ No write permission or file is read-only.</source>
     </message>
     <message>
         <source>Random File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Random File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -246,6 +246,7 @@ QMenuBar *ActionManager::buildMenuBar(QWidget *parent)
     addCloneOfAction(goMenu, "nextfile");
     addCloneOfAction(goMenu, "lastfile");
     addCloneOfAction(goMenu, "randomfile");
+    addCloneOfAction(goMenu, "previousrandomfile");
 
     menuBar->addMenu(goMenu);
     // End of go menu
@@ -760,6 +761,8 @@ void ActionManager::actionTriggered(QAction *triggeredAction, MainWindow *releva
         relevantWindow->lastFile();
     } else if (key == "randomfile") {
         relevantWindow->randomFile();
+    } else if (key == "previousrandomfile") {
+        relevantWindow->previousRandomFile();
     } else if (key == "saveframeas") {
         relevantWindow->saveFrameAs();
     } else if (key == "pause") {
@@ -949,6 +952,10 @@ void ActionManager::initializeActionLibrary()
     auto *randomFileAction = new QAction(qvApp->iconFromFont(Qv::MaterialIcon::Shuffle), tr("&Random File"));
     randomFileAction->setData({"folderdisable"});
     actionLibrary.insert("randomfile", randomFileAction);
+
+    auto *previousRandomFileAction = new QAction(qvApp->iconFromFont(Qv::MaterialIcon::Shuffle), tr("&Previous Random File"));
+    previousRandomFileAction->setData({"folderdisable"});
+    actionLibrary.insert("previousrandomfile", previousRandomFileAction);
 
     auto *saveFrameAsAction = new QAction(qvApp->iconFromFont(Qv::MaterialIcon::Save), tr("Save Frame &As..."));
     saveFrameAsAction->setData({"gifdisable"});

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1291,7 +1291,12 @@ void MainWindow::lastFile()
 
 void MainWindow::randomFile()
 {
-    graphicsView->goToFile(Qv::GoToFileMode::Random);
+    graphicsView->goToFile(Qv::GoToFileMode::NextRandom);
+}
+
+void MainWindow::previousRandomFile()
+{
+    graphicsView->goToFile(Qv::GoToFileMode::PreviousRandom);
 }
 
 void MainWindow::saveFrameAs()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -128,6 +128,7 @@ public:
     void lastFile();
 
     void randomFile();
+    void previousRandomFile();
 
     void saveFrameAs();
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -359,14 +359,24 @@ QVImageCore::GoToFileResult QVImageCore::goToFile(const Qv::GoToFileMode mode, c
         searchDirection = -1;
         break;
     }
-    case Qv::GoToFileMode::Random:
+    case Qv::GoToFileMode::NextRandom:
     {
         if (fileList.size() > 1)
         {
-            int randomIndex = QRandomGenerator::global()->bounded(fileList.size()-1);
-            newIndex = randomIndex + (randomIndex >= newIndex ? 1 : 0);
+            randomGenerator.ensureParamsUpToDate(fileList.size());
+            newIndex = randomGenerator.nextIndex(newIndex);
+            searchDirection = 0;
         }
-        searchDirection = 1;
+        break;
+    }
+    case Qv::GoToFileMode::PreviousRandom:
+    {
+        if (fileList.size() > 1)
+        {
+            randomGenerator.ensureParamsUpToDate(fileList.size());
+            newIndex = randomGenerator.previousIndex(newIndex);
+            searchDirection = 0;
+        }
         break;
     }
     }

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -14,6 +14,7 @@
 #include <QCache>
 #include <QElapsedTimer>
 #include <QColorSpace>
+#include "qvrandom.h"
 
 class QVImageCore : public QObject
 {
@@ -129,6 +130,8 @@ private:
     int largestDimension {1920};
 
     bool waitingOnLoad {false};
+
+    QVRandom randomGenerator;
 };
 
 #endif // QVIMAGECORE_H

--- a/src/qvnamespace.h
+++ b/src/qvnamespace.h
@@ -134,7 +134,8 @@ namespace Qv
         Previous,
         Next,
         Last,
-        Random
+        NextRandom,
+        PreviousRandom
     };
 
     enum class MaterialIcon : quint16

--- a/src/qvrandom.cpp
+++ b/src/qvrandom.cpp
@@ -1,0 +1,68 @@
+#include "qvrandom.h"
+
+#include <random>
+
+// Simple reversible random generator
+// Build a random permutation R of [0..N-1] and store the actual position of
+// each value in positions P. To get the next/previous value of i, get its
+// position, increment/decrement it and get its permutation value.
+// Next/previous = R[(P[i] ± 1) mod N]
+
+void QVRandom::ensureParamsUpToDate(int n)
+{
+    if (n <= 0) {
+        modN = 0;
+        permutation.clear();
+        positions.clear();
+        return;
+    }
+    if (n != modN) {
+        modN = n;
+        permutation.resize(modN);
+        positions.resize(modN);
+        for (int i = 0; i < modN; i++)
+            permutation[i] = i;
+
+        static std::mt19937 rng(std::random_device{}());
+
+        // shuffle permutation array using Fisher-Yates algorithm
+        for (int i = modN - 1; i > 0; i--) {
+            std::uniform_int_distribution<int> distribute(0, i);
+            int j = distribute(rng);
+            std::swap(permutation[i], permutation[j]);
+        }
+        for (int i = 0; i < modN; i++)
+            positions[permutation[i]] = i;
+    }
+}
+
+int QVRandom::nextIndex(int currentIndex) const
+{
+    if (modN <= 0)
+        return currentIndex;
+    int idx = currentIndex;
+    if (idx < 0)
+        idx = 0;
+    else if (idx >= modN)
+        idx %= modN;
+    int k = positions[idx];
+    // k' = (k + 1) mod N
+    k++;
+    if (k == modN) k = 0;
+    return permutation[k];
+}
+
+int QVRandom::previousIndex(int currentIndex) const
+{
+    if (modN <= 0)
+        return currentIndex;
+    int idx = currentIndex;
+    if (idx < 0)
+        idx = 0;
+    else if (idx >= modN)
+        idx %= modN;
+    int k = positions[idx];
+    k--;
+    if (k < 0) k = modN - 1;
+    return permutation[k];
+}

--- a/src/qvrandom.h
+++ b/src/qvrandom.h
@@ -1,0 +1,19 @@
+#ifndef QVRANDOM_H
+#define QVRANDOM_H
+
+#include <QtCore/QVector>
+
+class QVRandom
+{
+public:
+    void ensureParamsUpToDate(int n);
+    int nextIndex(int currentIndex) const;
+    int previousIndex(int currentIndex) const;
+
+private:
+    int modN{ 0 };
+    QVector<int> permutation;
+    QVector<int> positions;
+};
+
+#endif // QVRANDOM_H

--- a/src/shortcutmanager.cpp
+++ b/src/shortcutmanager.cpp
@@ -79,6 +79,7 @@ void ShortcutManager::initializeShortcutsList()
     shortcutsList.append({tr("Next File"), "nextfile", QStringList(QKeySequence(Qt::Key_Right).toString()), {}});
     shortcutsList.append({tr("Last File"), "lastfile", QStringList(QKeySequence(Qt::Key_End).toString()), {}});
     shortcutsList.append({tr("Random File"), "randomfile", QStringList(QKeySequence(Qt::Key_R).toString()), {}});
+    shortcutsList.append({tr("Previous Random File"), "previousrandomfile", QStringList(QKeySequence(Qt::SHIFT | Qt::Key_R).toString()), {}});
     shortcutsList.append({tr("Zoom In"), "zoomin", keyBindingsToStringList(QKeySequence::ZoomIn), {}});
     // Allow zooming with Ctrl + plus like a regular person (without holding shift)
     if (!shortcutsList.last().defaultShortcuts.contains(QKeySequence(Qt::CTRL | Qt::Key_Equal).toString()))

--- a/src/src.pri
+++ b/src/src.pri
@@ -20,7 +20,8 @@ SOURCES += \
     $$PWD/settingsmanager.cpp \
     $$PWD/shortcutmanager.cpp \
     $$PWD/simplefonticonengine.cpp \
-    $$PWD/updatechecker.cpp
+    $$PWD/updatechecker.cpp \
+    $$PWD/qvrandom.cpp
 
 macx:!CONFIG(NO_COCOA):SOURCES += $$PWD/qvcocoafunctions.mm
 win32:!CONFIG(NO_WIN32):SOURCES += $$PWD/qvwin32functions.cpp
@@ -48,7 +49,8 @@ HEADERS += \
     $$PWD/settingsmanager.h \
     $$PWD/shortcutmanager.h \
     $$PWD/simplefonticonengine.h \
-    $$PWD/updatechecker.h
+    $$PWD/updatechecker.h \
+    $$PWD/qvrandom.h
 
 macx:!CONFIG(NO_COCOA):HEADERS += $$PWD/qvcocoafunctions.h
 win32:!CONFIG(NO_WIN32):HEADERS += $$PWD/qvwin32functions.h


### PR DESCRIPTION
This is a great project! Thank you!

This PR allows moving backward in the random sequence by using a reversible random generator. It adds a `Previous Random File` action and allows setting keyboard shortcut for it. It replaces the QT random generator with a reversible one. Random navigation algorithm is fairly simple: We keep two arrays sized to the number of files in the folder:
* permutation[i]: A permutation of [0..N-1] that maps file position i to a random file index.
* positions[random-index]: Reverse maps a random file index to its position i in the permutation.

To get next/previous random index: Compute i = positions[current-index], then i = (i ± 1) % N, and take permutation[i].
The permutation is reinitialized with a different random seed at application startup or whenever the number of files in the folder changes. Since we use a permutation of 0 through N−1, all images are guaranteed to be visited before the sequence repeats.

Overhead: Two integer arrays of length N. Assuming 32-bit ints, that’s N * 4 * 2 bytes. For 10’000 files ~ 78 KB, which is negligible.

The random generator is put in `qvrandom.h/.cpp` files.
